### PR TITLE
add ci-reporting, errorprone profile and record static code analysis

### DIFF
--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -48,7 +48,7 @@ def call(Map params = [:]) {
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     def forceCiReporting = params.containsKey('forceCiReporting') ? params.forceReporting : false	
     def runCiReporting = forceCiReporting || env.BRANCH_NAME == 'master'
-    echo "runCiReporting " + runCiReporting
+    echo "runCiReporting: " + runCiReporting + ", forceCiReporting: "+ forceCiReporting
 	  
     taskContext['failFast'] = failFast;
     taskContext['tmpWs'] = tmpWs;

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -225,7 +225,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
               }
             }
             if(recordReporting) {
-              recordIssues id: "${stageId}", name: "Static Analysis", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]    
+              recordIssues id: "${os}-jdk${jdk}", name: "Static Analysis", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]    
               jacoco inclusionPattern: '**/org/apache/maven/**/*.class',
                      exclusionPattern: '',
                      execPattern: '**/target/jacoco.exec',

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -136,13 +136,14 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext, runCiReportin
   if (Integer.parseInt(jdk) >= 11 && !taskContext['ciReportingRunned'] && runCiReporting) {
     cmd += "-Pci-reporting -Perrorprone" 
     taskContext['ciReportingRunned'] = true	 
-    recordReporting = true	  
+    recordReporting = true	
+    echo "CI Reporting triggered for OS: ${os} JDK: ${jdk} Maven: ${maven}" 	  
   }
 	
 
   if (plan == 'build') {
       cmd += 'clean'
-      if (env.BRANCH_NAME == 'master' && jdk == '17' && maven == '3.6.x' && os == 'linux' ) {
+      if (env.BRANCH_NAME == 'master' && jdk == '17' && maven == '3.8.x' && os == 'linux' ) {
         cmd += 'deploy'		      
       } else {
         cmd += 'verify -Dpgpverify.skip'      

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -135,7 +135,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
 //  } else { // Requires authorization on SonarQube first
 //    cmd += 'sonar:sonar'
   }	  
-  if (nteger.parseInt(jdk) >= 11 && !taskContext['ciReportingRunned']) {
+  if (Integer.parseInt(jdk) >= 11 && !taskContext['ciReportingRunned']) {
     cmd += "-Pci-reporting -Perrorprone" 
     taskContext['ciReportingRunned'] = true	  
   }

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -135,7 +135,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext, runCiReportin
     taskContext.extraCmd  
   ]
   if (Integer.parseInt(jdk) >= 11 && !taskContext['ciReportingRunned'] && runCiReporting) {
-    cmd += "-Pci-reporting -Perrorprone" 
+    cmd += "-Pci-reporting -Perrorprone -U" 
     taskContext['ciReportingRunned'] = true	 
     recordReporting = true	
     echo "CI Reporting triggered for OS: ${os} JDK: ${jdk} Maven: ${maven}" 	  

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -133,7 +133,12 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
     cmd += '-Dfindbugs.skip=true'
 //  } else { // Requires authorization on SonarQube first
 //    cmd += 'sonar:sonar'
-  }
+  } else {
+    // TODO make this as a parameter such ciReportingProfle	  
+    cmd += '-Pci-reporting -Perrorprone' 	  
+  }	  
+	  
+	
 
   if (plan == 'build') {
       cmd += 'clean'
@@ -154,6 +159,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
       cmd += 'verify'
       cmd += '-Papache-release'
   }
+  def ciReporting = first	
   def disablePublishers = !first
   first = false
   String stageId = "${os}-jdk${jdk}-m${maven}_${plan}"
@@ -215,6 +221,9 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
                  bat cmd.join(' ')
                 }
               }
+            }
+            if(ciReporting) {
+              recordIssues id: "${stageId}", name: "Static Analysis", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]    
             }
           } catch (Throwable e) {
             archiveDirs(taskContext.archives, stageDir)

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -48,6 +48,7 @@ def call(Map params = [:]) {
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     def forceCiReporting = params.containsKey('forceCiReporting') ? params.forceReporting : false	
     def runCiReporting = forceCiReporting || env.BRANCH_NAME == 'master'
+    echo "runCiReporting " + runCiReporting
 	  
     taskContext['failFast'] = failFast;
     taskContext['tmpWs'] = tmpWs;

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -225,7 +225,9 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
               }
             }
             if(recordReporting) {
-              recordIssues id: "${os}-jdk${jdk}", name: "Static Analysis", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]    
+              recordIssues id: "${os}-jdk${jdk}", name: "Static Analysis", 
+		           aggregatingResults: true, enabledForFailure: true, 
+		           tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne(),taglist()]    
               jacoco inclusionPattern: '**/org/apache/maven/**/*.class',
                      exclusionPattern: '',
                      execPattern: '**/target/jacoco.exec',

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -160,7 +160,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
       cmd += 'verify'
       cmd += '-Papache-release'
   }
-  def ciReporting = first	
+  def ciReporting = !taskContext['ciReportingRunned']	
   def disablePublishers = !first
   first = false
   String stageId = "${os}-jdk${jdk}-m${maven}_${plan}"

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -44,6 +44,7 @@ def call(Map params = [:]) {
     def failFast = false;
     def siteJdks = params.containsKey('siteJdk') ? params.siteJdk : ['8']
     def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.8.x'
+    def siteOs = params.containsKey('siteOs') ? params.siteOs : ['linux']
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     
     taskContext['failFast'] = failFast;
@@ -67,7 +68,7 @@ def call(Map params = [:]) {
       
       for (def jdk in siteJdks) {
         // doesn't work for multimodules yet
-        doCreateTask( os, jdk, siteMvn, tasks, first, 'site', taskContext )
+        doCreateTask( siteOs, jdk, siteMvn, tasks, first, 'site', taskContext )
       }
       
       // run with apache-release profile, consider it a dryRun with SNAPSHOTs

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -46,7 +46,7 @@ def call(Map params = [:]) {
     def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.8.x'
     def siteOses = params.containsKey('siteOs') ? params.siteOs : ['linux']
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
-    def forceCiReporting = params.containsKey('forceCiReporting') ? params.forceReporting : false	
+    def forceCiReporting = params.containsKey('forceCiReporting') ? params.forceCiReporting : false	
     def runCiReporting = forceCiReporting || env.BRANCH_NAME == 'master'
     echo "runCiReporting: " + runCiReporting + ", forceCiReporting: "+ forceCiReporting
 	  

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -64,10 +64,10 @@ def call(Map params = [:]) {
         doCreateTask( os, jdk, mvn, tasks, first, 'build', taskContext )
       }
       
-	  for (def jdk in siteJdks) {
+      for (def jdk in siteJdks) {
         // doesn't work for multimodules yet
         doCreateTask( os, jdk, siteMvn, tasks, first, 'site', taskContext )
-	  }
+      }
       
       // run with apache-release profile, consider it a dryRun with SNAPSHOTs
       // doCreateTask( os, siteJdk, siteMvn, tasks, first, 'release', taskContext )
@@ -241,6 +241,6 @@ def archiveDirs(archives, stageDir) {
       archives.each { archivePrefix, pathToContent ->
 	    zip(zipFile: "${archivePrefix}-${stageDir}.zip", dir: pathToContent, archive: true)
       }
-	}
+    }
   }
 }

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -52,6 +52,7 @@ def call(Map params = [:]) {
     taskContext['archives'] = params.archives
     taskContext['siteWithPackage'] = params.containsKey('siteWithPackage') ? params.siteWithPackage : false // workaround for MNG-7289
     taskContext['extraCmd'] = params.containsKey('extraCmd') ? params.extraCmd : ''
+    taskContext['ciReportingRunned'] = false	  
 
     Map tasks = [failFast: failFast]
     boolean first = true
@@ -133,11 +134,11 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
     cmd += '-Dfindbugs.skip=true'
 //  } else { // Requires authorization on SonarQube first
 //    cmd += 'sonar:sonar'
-  } else {
-    // TODO make this as a parameter such ciReportingProfle	  
-    cmd += '-Pci-reporting -Perrorprone' 	  
   }	  
-	  
+  if (jdk >= 11 and !taskContext['ciReportingRunned']) {
+    cmd += "-Pci-reporting -Perrorprone" 
+    taskContext['ciReportingRunned'] = true	  
+  }
 	
 
   if (plan == 'build') {

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -135,7 +135,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
 //  } else { // Requires authorization on SonarQube first
 //    cmd += 'sonar:sonar'
   }	  
-  if (jdk >= 11 && !taskContext['ciReportingRunned']) {
+  if (nteger.parseInt(jdk) >= 11 && !taskContext['ciReportingRunned']) {
     cmd += "-Pci-reporting -Perrorprone" 
     taskContext['ciReportingRunned'] = true	  
   }

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -38,12 +38,12 @@ def call(Map params = [:]) {
 	// minimum, LTS, current and next ea
     def jdks = params.containsKey('jdks') ? params.jdks : params.containsKey('jdk') ? params.jdk : ['8','11','17']
     def jdkMin = jdks[0];
-    def mavens = params.containsKey('maven') ? params.maven : ['3.5.x','3.6.x']
+    def mavens = params.containsKey('maven') ? params.maven : ['3.6.x','3.8.x']
     // def failFast = params.containsKey('failFast') ? params.failFast : true
     // Just temporarily
     def failFast = false;
-    def siteJdks = params.containsKey('siteJdk') ? params.siteJdk : ['8','17']
-    def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.6.x'
+    def siteJdks = params.containsKey('siteJdk') ? params.siteJdk : ['8']
+    def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.8.x'
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     
     taskContext['failFast'] = failFast;

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -50,6 +50,7 @@ def call(Map params = [:]) {
     taskContext['tmpWs'] = tmpWs;
     taskContext['archives'] = params.archives
     taskContext['siteWithPackage'] = params.containsKey('siteWithPackage') ? params.siteWithPackage : false // workaround for MNG-7289
+    taskContext['extraCmd'] = params.containsKey('extraCmd') ? params.extraCmd : ''
 
     Map tasks = [failFast: failFast]
     boolean first = true
@@ -122,9 +123,9 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
   def cmd = [
     'mvn', '-V',
     '-P+run-its',
-    '-Dmaven.test.failure.ignore=true',
     '-Dfindbugs.failOnError=false',
     '-e',
+    taskContext.extraCmd  
   ]
   if (!first) {
     cmd += '-Dfindbugs.skip=true'

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -226,6 +226,11 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
             }
             if(recordReporting) {
               recordIssues id: "${stageId}", name: "Static Analysis", aggregatingResults: true, enabledForFailure: true, tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne()]    
+              jacoco inclusionPattern: '**/org/apache/maven/**/*.class',
+                     exclusionPattern: '',
+                     execPattern: '**/target/jacoco.exec',
+                     classPattern: '**/target/classes',
+                     sourcePattern: '**/src/main/java'		    
               recordReporting = false;		    
             }
           } catch (Throwable e) {

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -227,7 +227,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
             if(recordReporting) {
               recordIssues id: "${os}-jdk${jdk}", name: "Static Analysis", 
 		           aggregatingResults: true, enabledForFailure: true, 
-		           tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne(),taglist()]    
+		           tools: [mavenConsole(), java(), checkStyle(), spotBugs(), pmdParser(), errorProne(),tagList()]    
               jacoco inclusionPattern: '**/org/apache/maven/**/*.class',
                      exclusionPattern: '',
                      execPattern: '**/target/jacoco.exec',

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -44,7 +44,7 @@ def call(Map params = [:]) {
     def failFast = false;
     def siteJdks = params.containsKey('siteJdk') ? params.siteJdk : ['8']
     def siteMvn = params.containsKey('siteMvn') ? params.siteMvn : '3.8.x'
-    def siteOs = params.containsKey('siteOs') ? params.siteOs : ['linux']
+    def siteOses = params.containsKey('siteOs') ? params.siteOs : ['linux']
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     
     taskContext['failFast'] = failFast;
@@ -65,15 +65,16 @@ def call(Map params = [:]) {
         def mvn = jenkinsEnv.mavenForJdk(jdk)
         doCreateTask( os, jdk, mvn, tasks, first, 'build', taskContext )
       }
-      
-      for (def jdk in siteJdks) {
-        // doesn't work for multimodules yet
-        doCreateTask( siteOs, jdk, siteMvn, tasks, first, 'site', taskContext )
-      }
-      
+          
       // run with apache-release profile, consider it a dryRun with SNAPSHOTs
       // doCreateTask( os, siteJdk, siteMvn, tasks, first, 'release', taskContext )
     }
+    for (String os in siteOses) {	  
+      for (def jdk in siteJdks) {
+        // doesn't work for multimodules yet
+        doCreateTask( os, jdk, siteMvn, tasks, first, 'site', taskContext )
+      }	  
+    } 	    
     // run the parallel builds
     parallel(tasks)
 

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -135,7 +135,7 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
 //  } else { // Requires authorization on SonarQube first
 //    cmd += 'sonar:sonar'
   }	  
-  if (jdk >= 11 and !taskContext['ciReportingRunned']) {
+  if (jdk >= 11 && !taskContext['ciReportingRunned']) {
     cmd += "-Pci-reporting -Perrorprone" 
     taskContext['ciReportingRunned'] = true	  
   }

--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -38,7 +38,7 @@ def call(Map params = [:]) {
 	// minimum, LTS, current and next ea
     def jdks = params.containsKey('jdks') ? params.jdks : params.containsKey('jdk') ? params.jdk : ['8','11','17']
     def jdkMin = jdks[0];
-    def mavens = params.containsKey('maven') ? params.maven : ['3.2.x','3.3.x','3.5.x','3.6.x']
+    def mavens = params.containsKey('maven') ? params.maven : ['3.5.x','3.6.x']
     // def failFast = params.containsKey('failFast') ? params.failFast : true
     // Just temporarily
     def failFast = false;

--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -39,6 +39,7 @@ def call(Map params = [:]) {
     def jdks = params.containsKey('jdks') ? params.jdks : params.containsKey('jdk') ? params.jdk : ['8','11','17']
     def maven = params.containsKey('maven') ? params.maven : '3.6.x'
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
+    def extraCmd = params.containsKey('extraCmd') ? params.extraCmd : ''
     // def failFast = params.containsKey('failFast') ? params.failFast : true
     // Just temporarily
     def failFast = false;
@@ -57,8 +58,8 @@ def call(Map params = [:]) {
         def cmd = [
           'mvn', '-V',
           '-P+run-its',
-          '-Dmaven.test.failure.ignore=true',
           '-Dfindbugs.failOnError=false',
+          extraCmd
         ]
         if (!first) {
           cmd += '-Dfindbugs.skip=true'

--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -37,7 +37,7 @@ def call(Map params = [:]) {
     def oses = params.containsKey('os') ? params.os : ['linux', 'windows']
     // minimum, LTS, current and next ea
     def jdks = params.containsKey('jdks') ? params.jdks : params.containsKey('jdk') ? params.jdk : ['8','11','17']
-    def maven = params.containsKey('maven') ? params.maven : '3.6.x'
+    def maven = params.containsKey('maven') ? params.maven : '3.8.x'
     def tmpWs = params.containsKey('tmpWs') ? params.tmpWs : false
     def extraCmd = params.containsKey('extraCmd') ? params.extraCmd : ''
     // def failFast = params.containsKey('failFast') ? params.failFast : true

--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -66,7 +66,7 @@ def call(Map params = [:]) {
           extraCmd
         ]
         if (Integer.parseInt(jdk) >= 11 && !ciReportingRunned && runCiReporting) {
-          cmd += "-Pci-reporting -Perrorprone" 
+          cmd += "-Pci-reporting -Perrorprone -U" 
           ciReportingRunned = true	 
           echo "CI Reporting triggered for OS: ${os} JDK: ${jdk} Maven: ${maven}" 	  
         }


### PR DESCRIPTION
do not maven.test.failure.ignore per default as we do not even recommend using it (https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#testFailureIgnore) 