### PR TITLE
Remove openTasksPublisher from Maven options

### DIFF
--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -97,7 +97,6 @@ def call(Map params = [:]) {
                               options: [
                                 artifactsPublisher(disabled: disablePublishers),
                                 junitPublisher(ignoreAttachments: false),
-                                openTasksPublisher(disabled: disablePublishers),
                                 dependenciesFingerprintPublisher(disabled: disablePublishers),
     // DISABLED DUE TO INFRA-17514 invokerPublisher(),
                                 pipelineGraphPublisher(disabled: disablePublishers)


### PR DESCRIPTION
This option is just available when the unmaintained tasks plugin (https://plugins.jenkins.io/tasks/) is installed in Jenkins (https://plugins.jenkins.io/pipeline-maven/#plugin-content-report-publishers) which is no longer the case.