### PR TITLE
Run Maven wrapper with specific Maven version

### DIFF
--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -186,15 +186,20 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
             withEnv(["JAVA_HOME=${ tool "$jdkName" }",
                "PATH+MAVEN=${ tool "$jdkName" }/bin:${tool "$mvnName"}/bin",
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
-             dir (stageDir) {
-               GitCheckoutHelper.checkoutScm(this, scm, taskContext.fetchDepth)
-               if (isUnix()) {
-                 sh 'df -hT'
-                 sh cmd.join(' ')
-               } else {
-                 bat 'wmic logicaldisk get size,freespace,caption'
-                 bat cmd.join(' ')
-                }
+              dir (stageDir) {
+                GitCheckoutHelper.checkoutScm(this, scm, taskContext.fetchDepth)
+                def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${maven}"
+                def buildCmd = cmd.clone()
+                buildCmd[0] = isUnix() ? './mvnw' : 'mvnw.cmd'
+                if (isUnix()) {
+                  sh 'df -hT'
+                  sh wrapperSetup
+                  sh buildCmd.join(' ')
+                } else {
+                  bat 'wmic logicaldisk get size,freespace,caption'
+                  bat wrapperSetup
+                  bat buildCmd.join(' ')
+                 }
               }
             }
           } catch (Throwable e) {

--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -106,10 +106,15 @@ def call(Map params = [:]) {
                               ], publisherStrategy: 'EXPLICIT') {
                       dir ('m') {
                         GitCheckoutHelper.checkoutScm(this, scm, fetchDepth)
+                        def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${maven}"
+                        def buildCmd = cmd.clone()
+                        buildCmd[0] = isUnix() ? './mvnw' : 'mvnw.cmd'
                         if (isUnix()) {
-                          sh cmd.join(' ')
+                          sh wrapperSetup
+                          sh buildCmd.join(' ')
                         } else {
-                          bat cmd.join(' ')
+                          bat wrapperSetup
+                          bat buildCmd.join(' ')
                         }
                       }
                     }


### PR DESCRIPTION
Applies the pattern from apache/maven-gh-actions-shared branch v5 to Jenkins shared library:
1. Configures the Maven wrapper using `org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${maven}`
2. Executes build commands via `./mvnw` (or `mvnw.cmd` on Windows) instead of system `mvn`.