### PR TITLE
Give the wrapper a real Maven version, not a pattern

### DIFF
--- a/vars/asfMavenTlpPlgnBuild.groovy
+++ b/vars/asfMavenTlpPlgnBuild.groovy
@@ -188,7 +188,13 @@ def doCreateTask( os, jdk, maven, tasks, first, plan, taskContext )
                "MAVEN_OPTS=-Xms2g -Xmx4g -Djava.awt.headless=true"]) {
               dir (stageDir) {
                 GitCheckoutHelper.checkoutScm(this, scm, taskContext.fetchDepth)
-                def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${maven}"
+                // -Dmaven= becomes a download URL, so it needs a real version:
+                // "4.0.x" would write apache-maven-4.0.x-bin.zip and 404 later.
+                String mvnVersion = jenkinsEnv.mvnVersionFromPattern("${maven}")
+                if (mvnVersion == null) {
+                  error "No concrete Maven version for '${maven}'; cannot provision the wrapper"
+                }
+                def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${mvnVersion}"
                 def buildCmd = cmd.clone()
                 buildCmd[0] = isUnix() ? './mvnw' : 'mvnw.cmd'
                 if (isUnix()) {

--- a/vars/asfMavenTlpStdBuild.groovy
+++ b/vars/asfMavenTlpStdBuild.groovy
@@ -106,7 +106,14 @@ def call(Map params = [:]) {
                               ], publisherStrategy: 'EXPLICIT') {
                       dir ('m') {
                         GitCheckoutHelper.checkoutScm(this, scm, fetchDepth)
-                        def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${maven}"
+                        // -Dmaven= becomes a download URL, so it needs a real
+                        // version: "4.0.x" would write apache-maven-4.0.x-bin.zip
+                        // and 404 later.
+                        String mvnVersion = jenkinsEnv.mvnVersionFromPattern("${maven}")
+                        if (mvnVersion == null) {
+                          error "No concrete Maven version for '${maven}'; cannot provision the wrapper"
+                        }
+                        def wrapperSetup = "mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=${mvnVersion}"
                         def buildCmd = cmd.clone()
                         buildCmd[0] = isUnix() ? './mvnw' : 'mvnw.cmd'
                         if (isUnix()) {


### PR DESCRIPTION
**This fixes a live breakage.** The wrapper provisioning added in `53fd00c` (#22) passes `-Dmaven=${maven}`, but that value is the *pattern* the Jenkinsfiles supply — `"4.0.x"`, `"3.9.x"` — which exists to be mapped by `jenkinsEnv.mvnFromVersion` to a Jenkins **tool installation name**. The wrapper turns it into a download URL instead. Reproduced locally:

```
$ mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=4.0.x
exit 0
$ cat .mvn/wrapper/maven-wrapper.properties
distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.x/apache-maven-4.0.x-bin.zip
```

That URL is a 404, and so is the `3.9.x` equivalent. Because the wrapper goal itself exits 0, nothing fails until `./mvnw` tries to download — so every build going through `asfMavenTlpPlgnBuild` or `asfMavenTlpStdBuild` breaks, on Maven 3 and 4 alike.

This resolves the pattern through `jenkinsEnv.mvnVersionFromPattern` first and fails the stage when it cannot, instead of provisioning an URL that will not resolve.

**Requires apache/maven-jenkins-env#8**, which adds that method — please merge that one first.

Verified by reproducing the bad `distributionUrl` locally and confirming both URLs 404. The shared library itself cannot be executed outside Jenkins, so the wiring has not been run end to end.